### PR TITLE
[BUGFIX] make *RootPaths overridable

### DIFF
--- a/Configuration/TypoScript/constants.ts
+++ b/Configuration/TypoScript/constants.ts
@@ -1,7 +1,7 @@
 plugin.tx_ttaddress {
   view {
     # cat=plugin.tx_ttaddress/file; type=string; label=Path to template root (FE)
-    templateRootPath = EXT:tt_address/Resources/Private/Templates/Address/
+    templateRootPath = EXT:tt_address/Resources/Private/Templates/
     # cat=plugin.tx_ttaddress/file; type=string; label=Path to template partials (FE)
     partialRootPath = EXT:tt_address/Resources/Private/Partials/
     # cat=plugin.tx_ttaddress/file; type=string; label=Path to template layouts (FE)

--- a/Configuration/TypoScript/setup.ts
+++ b/Configuration/TypoScript/setup.ts
@@ -2,9 +2,18 @@
 
 plugin.tx_ttaddress {
   view {
-    templateRootPath = {$plugin.tx_ttaddress.view.templateRootPath}
-    partialRootPath = {$plugin.tx_ttaddress.view.partialRootPath}
-    layoutRootPath = {$plugin.tx_ttaddress.view.layoutRootPath}
+    templateRootPaths {
+      0 = EXT:tt_address/Resources/Private/Templates/
+      1 = {$plugin.tx_ttaddress.view.templateRootPath}
+    }
+    partialRootPaths {
+      0 = EXT:tt_address/Resources/Private/Partials/
+      1 = {$plugin.tx_ttaddress.view.partialRootPath}
+    }
+    layoutRootPaths {
+      0 = EXT:tt_address/Resources/Private/Layouts/
+      1 = {$plugin.tx_ttaddress.view.layoutRootPath}
+    }
   }
   settings {
     ## Override settings if empty in flexform


### PR DESCRIPTION
This bugfix closes #5 and #6. 
Tested on 7.6.31 and 8.7.20.